### PR TITLE
remove typeof from choose_pivot(...)

### DIFF
--- a/include/generic.h
+++ b/include/generic.h
@@ -54,7 +54,7 @@ namespace alg
 	static inline int choose_pivot(int i,int j)
 	{
 		assert(j>=i);
-		typeof(i) length = j - i;
+		int length = j - i;
 		return i+(rand()%length);
 	}
 


### PR DESCRIPTION
It's not making any sense to use typeof(i) to define length, since 'i' is obviously a 'int'. And it's probably not a good idea to put the choose pivot function in a separate file, this will force user to call srand() unnaturally.
