### PR TITLE
Always returns start and end nodes when a path is found in astar

### DIFF
--- a/include/astar.h
+++ b/include/astar.h
@@ -100,6 +100,7 @@ namespace alg {
 
 					if(cx == (int)x2 && cy==(int)y2) {	// we reached (x2,y2)
 						// reconstruct path & return
+						as->num_nodes = 2;
 						uint32_t tmp = x2*ncol+y2;
 						while((tmp=came_from[tmp]) != x1*ncol+y1) {
 							as->num_nodes++;
@@ -109,10 +110,14 @@ namespace alg {
 
 						tmp = x2*ncol+y2;
 						int idx=0;
+						as->path[idx++] = x2;
+						as->path[idx++] = y2;
 						while((tmp=came_from[tmp]) != x1*ncol+y1) {
 							as->path[idx++] = tmp/ncol;
 							as->path[idx++] = tmp%ncol;
 						}
+						as->path[idx++] = x1;
+						as->path[idx++] = y1;
 						return as;
 					}
 


### PR DESCRIPTION
This fix will make astar always returns the start and end node when a path is found.

Because, without this fix, one can not make a difference between an empty result (no path) and a 2 cells path (a path from a cell and its adjacent cell).

I am now sure you will want to integrate this one because it will breaks existing code that will not expect the start and end node to be in the result.

But I think it makes sense anyways.

Let me know if you have questions!
