### PR TITLE
Fix cmake build fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,15 @@ include_directories( "include" )
 include_directories( "." )
 if( MSVC )
 	include_directories( "msvc" )
+	SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /FI\"msvc/alg_vs.h\"" ) 
+	message( ${CMAKE_CXX_FLAGS} )
 endif()
 
 #add_executable(word_seg "src/word_seg_demo.cpp")
 #add_executable(astar "src/astar_demo.cpp")
 
 file( GLOB APP_SOURCES src/*.cpp )
-SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /FI\"msvc/alg_vs.h\"" ) 
-message( ${CMAKE_CXX_FLAGS} )
+
 foreach( appsourcefile ${APP_SOURCES} )
 	get_filename_component( demo_name ${appsourcefile} NAME_WE )
 	add_executable( ${demo_name} ${appsourcefile} )


### PR DESCRIPTION
Reproduction:
system: ubuntu16.04, cmake version: 3.14.4, gcc version: 5.5.0

run: cd build & cmake -B . -S ..

Solution: move msvc workaround to if context